### PR TITLE
Make the LoopTask run the checks of its interface before running the one...

### DIFF
--- a/hqc_meas/tasks/tasks_logic/loop_task.py
+++ b/hqc_meas/tasks/tasks_logic/loop_task.py
@@ -34,6 +34,28 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
     task_database_entries = set_default({'point_number': 11, 'index': 1,
                                          'value': 0})
 
+    def check(self, *args, **kwargs):
+        """ Overriden so that interface check are run before children ones.
+
+        """
+        test = True
+        traceback = {}
+        if not self.interface:
+            traceback[self.task_name + '_interface'] = 'Missing interface'
+            return False, traceback
+
+        i_test, i_traceback = self.interface.check(*args, **kwargs)
+
+        traceback.update(i_traceback)
+        test &= i_test
+
+        c_test, c_traceback = ComplexTask.check(self, *args, **kwargs)
+
+        traceback.update(c_traceback)
+        test &= c_test
+
+        return test, traceback
+
     def perform_loop(self, iterable):
         """ Perform the loop on the iterable calling all child tasks at each
         iteration.

--- a/tests/tasks/logic_tasks/test_loop_task.py
+++ b/tests/tasks/logic_tasks/test_loop_task.py
@@ -149,6 +149,13 @@ class TestLoopTask(object):
         assert_false(traceback)
         assert_equal(self.task.get_from_database('Test_point_number'), 11)
 
+        interface.iterable = 'dict(a=1)'
+        test, traceback = self.task.check()
+        assert_true(test)
+        assert_false(traceback)
+        assert_equal(self.task.get_from_database('Test_point_number'), 1)
+        assert_equal(self.task.get_from_database('Test_value'), 'a')
+
     def test_check_iterable_interface2(self):
         # Test handling a wrong iterable formula.
         interface = IterableLoopInterface()
@@ -170,6 +177,18 @@ class TestLoopTask(object):
         assert_false(test)
         assert_equal(len(traceback), 1)
         assert_in('root/Test', traceback)
+
+    def test_check_execution_order(self):
+        # Test that the interface checks are run before the children checks.
+        interface = IterableLoopInterface()
+        interface.iterable = '[(1, 0)]'
+        self.task.interface = interface
+
+        subiter = IterableLoopInterface(iterable='{Test_value}')
+        self.task.children_task = [LoopTask(interface=subiter)]
+
+        test, traceback = self.task.check()
+        assert_true(test)
 
     def test_perform1(self):
         # Test performing a simple loop no timing. Iterable interface.


### PR DESCRIPTION
...s from its children. Add the corresponding test and a test for the usecase of a dict as iterable (fix was merged sooner today)

fixes #7 
